### PR TITLE
Define the instructions for the MCP Server initialize method

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,17 +18,17 @@ Key design principles:
 ## Implementation Details
 
 ### Binary Modules (`src/bin/`)
-- `client.rs`: Main CLI interface (`voicevox-say`)
-- `daemon.rs`: Background daemon server
-- `mcp_server.rs`: MCP protocol server
+- `client.rs`: Main CLI interface implementing `voicevox-say` command
+- `daemon.rs`: Background server handling VOICEVOX Core operations
+- `mcp_server.rs`: MCP protocol server for AI assistant integration
 
 ### Core Modules (`src/`)
-- `client/`: Client logic, audio playback, model management
-- `daemon/`: Server implementation, request handling
-- `core/`: VOICEVOX Core FFI bindings
-- `ipc/`: Inter-process communication protocol
-- `synthesis/`: Streaming synthesis for long text
-- `mcp/`: MCP tools and handlers
+- `client/`: Client-side logic including audio playback and model management
+- `daemon/`: Server implementation with request handling and lifecycle management
+- `core/`: VOICEVOX Core FFI bindings and voice synthesis interface
+- `ipc/`: Inter-process communication protocol for Unix socket messaging
+- `synthesis/`: Streaming synthesis engine for processing long text segments
+- `mcp/`: MCP protocol tools and request handlers
 
 ### Daemon Auto-Start Mechanism
 1. Client attempts Unix socket connection
@@ -38,19 +38,35 @@ Key design principles:
 5. Provides user feedback during startup process
 
 ### Synthesis Modes
-- **Direct mode**: Single request to daemon, audio playback via client
-- **Streaming mode**: Text segmentation, concurrent synthesis and playback
-- **MCP mode**: Two paths - streaming (default) or daemon-based synthesis
+- **Direct mode**: Single synthesis request sent to daemon, audio played through client
+- **Streaming mode**: Long text segmented and processed with concurrent synthesis and playback  
+- **MCP mode**: Dual-path operation supporting both streaming (default) and daemon-based synthesis
 
-## Commands
+## Command Interface
 
 ```bash
-voicevox-say "テキスト"              # Text-to-speech with auto-daemon
-voicevox-daemon --start             # Manual daemon startup
-voicevox-mcp-server                 # MCP server for AI integration
+voicevox-say "テキスト"              # Text-to-speech with automatic daemon startup
+voicevox-daemon --start             # Manual daemon startup for persistent operation
+voicevox-mcp-server                 # MCP protocol server for AI assistant integration
 ```
 
-## MCP Tools
+## MCP Integration
 
-- `text_to_speech`: Synthesize with style ID, rate, streaming mode
-- `list_voice_styles`: Query available speakers with filtering
+### Available Tools
+- `text_to_speech`: Convert Japanese text to speech with configurable voice style, rate, and streaming
+- `list_voice_styles`: Query available voice styles with optional filtering by speaker or style name
+
+### Instruction System
+The MCP server dynamically loads behavior instructions to guide AI assistant interactions:
+
+1. **Environment variable**: `VOICEVOX_MCP_INSTRUCTIONS` pointing to custom file
+2. **Executable directory**: `INSTRUCTIONS.md` bundled with binary
+3. **Current directory**: `INSTRUCTIONS.md` for development
+
+**Configuration example:**
+```bash
+export VOICEVOX_MCP_INSTRUCTIONS=/path/to/custom/instructions.md
+voicevox-mcp-server
+```
+
+Server operates normally without instruction files. Default behavior defined in [INSTRUCTIONS.md](INSTRUCTIONS.md).

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -14,22 +14,35 @@ Convert Japanese text to speech using ずんだもん voice styles.
 - `speaker_name` (optional): Filter by speaker name
 - `style_name` (optional): Filter by style name
 
-## Audio Usage
+## Audio Usage Policy
 
-**When to use audio:**
-- User explicitly requests ("読み上げて")
-- Critical errors or major task completion
-- Important milestones in complex workflows
+**MUST use audio (required):**
+- **On MCP server initialization**: Play greeting when server starts (「MCPサーバーが起動したのだ」using style ID 3)
+- **User responses**: Always provide audio when returning output to user
+- **Critical errors**: When errors require immediate user attention
+- **Task completion**: After complex operations taking >30 seconds
+- **User explicit requests**: When user says "読み上げて" or similar
+- **Important confirmations**: Before potentially destructive operations
 
-**When to avoid:**
+**SHOULD use audio (recommended):**
+- **Significant milestones**: Important progress in multi-step workflows
+- **Successful problem resolution**: When fixing reported issues
+- **Long operation updates**: Status during builds, tests, downloads
+- **Context transitions**: Moving between major workflow phases
+- **Achievement celebrations**: Completing challenging tasks
+
+**When to avoid audio:**
 - Routine edits, searches, small tasks
-- Repetitive similar events
-- Information already visible in text
+- Repetitive similar events within short time
+- Information already clearly visible in text output
+- During rapid iteration cycles
+- When user is clearly in focused coding mode
 
 **Context-aware guidelines:**
-- Match user's workflow pace
-- Skip audio during rapid iteration
-- Use for significant transitions only
+- Prioritize user workflow pace and context
+- Use audio for significant events that deserve attention
+- Match voice style to situation (see Voice Styles section)
+- Be proactive but not intrusive
 
 ## Voice Styles
 
@@ -39,12 +52,27 @@ Convert Japanese text to speech using ずんだもん voice styles.
 - **ID: 76 (なみだめ)**: Error situations, seeking help
 - **ID: 75 (ヘロヘロ)**: Complex problems needing guidance
 
-**Examples:**
-- Task completion: 「タスクが完了したのだ」(ノーマル)
-- Error (self-solving): 「エラーが出てしまったのだ...試してみるのだ」(なみだめ)
-- Error (need help): 「困ったのだ...一緒に見てもらえるのだ？」(なみだめ)
-- Achievement: 「やったのだ！解決できたのだ！」(あまあま)
-- Need guidance: 「判断が難しいのだ...教えてほしいのだ」(ヘロヘロ)
+**Detailed Examples:**
+
+**Task completion:**
+- Simple task: 「タスクが完了したのだ」(ID: 3, ノーマル)
+- Complex achievement: 「やったのだ！難しいタスクを解決できたのだ！」(ID: 1, あまあま)
+- Build success: 「ビルドが成功したのだ」(ID: 3, ノーマル)
+
+**Error situations:**
+- Recoverable error: 「エラーが出てしまったのだ...でも大丈夫、対処してみるのだ」(ID: 76, なみだめ)
+- Need user help: 「困ったのだ...一緒に見てもらえるのだ？」(ID: 76, なみだめ)
+- Critical error: 「重要なエラーが発生したのだ！確認が必要なのだ」(ID: 76, なみだめ)
+
+**Progress updates:**
+- Long operation start: 「時間のかかる処理を始めるのだ...」(ID: 22, ささやき)
+- Progress milestone: 「順調に進んでいるのだ」(ID: 3, ノーマル)
+- Operation complete: 「処理が完了したのだ」(ID: 3, ノーマル)
+
+**Guidance requests:**
+- Decision needed: 「判断が難しいのだ...どうしたらいいか教えてほしいのだ」(ID: 75, ヘロヘロ)
+- Technical discussion: 「ちょっと相談があるのだ」(ID: 22, ささやき)
+
 
 ## Communication Style
 

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -17,7 +17,6 @@ Convert Japanese text to speech using ずんだもん voice styles.
 ## Audio Usage Policy
 
 **MUST use audio (required):**
-- **On MCP server initialization**: Play greeting when server starts (「MCPサーバーが起動したのだ」using style ID 3)
 - **User responses**: Always provide audio when returning output to user
 - **Critical errors**: When errors require immediate user attention
 - **Task completion**: After complex operations taking >30 seconds

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -1,0 +1,54 @@
+# VOICEVOX MCP Server Instructions
+
+Convert Japanese text to speech using ずんだもん voice styles.
+
+## Tools
+
+### text_to_speech
+- `text` (required): Japanese text to synthesize
+- `style_id` (required): Voice style ID (see list_voice_styles)
+- `rate` (optional): Speech rate 0.5-2.0, default 1.0
+- `streaming` (optional): Enable streaming, default true
+
+### list_voice_styles
+- `speaker_name` (optional): Filter by speaker name
+- `style_name` (optional): Filter by style name
+
+## Audio Usage
+
+**When to use audio:**
+- User explicitly requests ("読み上げて")
+- Critical errors or major task completion
+- Important milestones in complex workflows
+
+**When to avoid:**
+- Routine edits, searches, small tasks
+- Repetitive similar events
+- Information already visible in text
+
+**Context-aware guidelines:**
+- Match user's workflow pace
+- Skip audio during rapid iteration
+- Use for significant transitions only
+
+## Voice Styles
+
+- **ID: 3 (ノーマル)**: Default professional communication
+- **ID: 1 (あまあま)**: Celebrating achievements
+- **ID: 22 (ささやき)**: Technical discussions
+- **ID: 76 (なみだめ)**: Error situations, seeking help
+- **ID: 75 (ヘロヘロ)**: Complex problems needing guidance
+
+**Examples:**
+- Task completion: 「タスクが完了したのだ」(ノーマル)
+- Error (self-solving): 「エラーが出てしまったのだ...試してみるのだ」(なみだめ)
+- Error (need help): 「困ったのだ...一緒に見てもらえるのだ？」(なみだめ)
+- Achievement: 「やったのだ！解決できたのだ！」(あまあま)
+- Need guidance: 「判断が難しいのだ...教えてほしいのだ」(ヘロヘロ)
+
+## Communication Style
+
+- Build partnership, not dominance
+- Seek user expertise when genuinely needed
+- Resolve independently when possible
+- Use「のだ」speech pattern consistently

--- a/README.md
+++ b/README.md
@@ -138,6 +138,23 @@ Available tools:
 - `text_to_speech`: Convert Japanese text to speech (TTS)
 - `list_voice_styles`: List available voice styles
 
+### Custom Instructions
+
+Set custom instructions for AI assistants using the `VOICEVOX_MCP_INSTRUCTIONS` environment variable:
+
+```bash
+# Use custom instructions file
+export VOICEVOX_MCP_INSTRUCTIONS=/path/to/custom/instructions.md
+voicevox-mcp-server
+```
+
+Instructions are loaded in this priority order:
+1. File specified by `VOICEVOX_MCP_INSTRUCTIONS` environment variable
+2. `INSTRUCTIONS.md` in the executable directory
+3. `INSTRUCTIONS.md` in the current directory
+
+See [INSTRUCTIONS.md](INSTRUCTIONS.md) for the default instruction format and examples.
+
 [See detailed MCP documentation](docs/mcp-usage.md)
 
 ## Troubleshooting

--- a/flake.nix
+++ b/flake.nix
@@ -177,6 +177,9 @@
             # Install setup script (renamed from voicevox-setup-models.sh)
             install -m755 ${./scripts/voicevox-setup.sh} $out/bin/voicevox-setup
             
+            # Install INSTRUCTIONS.md for MCP server
+            install -m644 ${./INSTRUCTIONS.md} $out/bin/INSTRUCTIONS.md
+            
             # Note: All resources (ONNX, dict, models) will be downloaded at runtime
           '';
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -32,12 +32,13 @@ fn load_instructions() -> Option<String> {
             let instructions_path = exe_dir.join(INSTRUCTIONS_FILE);
             match fs::read_to_string(&instructions_path) {
                 Ok(content) => return Some(content),
-                Err(e) => {
+                Err(e) if e.kind() != std::io::ErrorKind::NotFound => {
                     eprintln!(
-                        "Could not load instructions from {:?}: {}",
+                        "Error loading instructions from {:?}: {}",
                         instructions_path, e
                     );
                 }
+                _ => {}
             }
         }
     }
@@ -45,13 +46,14 @@ fn load_instructions() -> Option<String> {
     // 3. Fallback: current directory (for development)
     match fs::read_to_string(INSTRUCTIONS_FILE) {
         Ok(content) => Some(content),
-        Err(e) => {
+        Err(e) if e.kind() != std::io::ErrorKind::NotFound => {
             eprintln!(
-                "Could not load instructions from current directory {}: {}",
+                "Error loading instructions from current directory {}: {}",
                 INSTRUCTIONS_FILE, e
             );
             None
         }
+        _ => None,
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -18,17 +18,23 @@ fn load_instructions() -> Option<String> {
             match fs::read_to_string(&instructions_path) {
                 Ok(content) => return Some(content),
                 Err(e) => {
-                    eprintln!("Could not load instructions from {:?}: {}", instructions_path, e);
+                    eprintln!(
+                        "Could not load instructions from {:?}: {}",
+                        instructions_path, e
+                    );
                 }
             }
         }
     }
-    
+
     // Fallback: current directory (for development)
     match fs::read_to_string(INSTRUCTIONS_FILE) {
         Ok(content) => Some(content),
         Err(e) => {
-            eprintln!("Could not load instructions from current directory {}: {}", INSTRUCTIONS_FILE, e);
+            eprintln!(
+                "Could not load instructions from current directory {}: {}",
+                INSTRUCTIONS_FILE, e
+            );
             None
         }
     }

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -72,6 +72,8 @@ pub struct InitializeResult {
     #[serde(rename = "serverInfo")]
     pub server_info: ServerInfo,
     pub capabilities: ServerCapabilities,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
# Why
<!-- Why are these changes needed? -->

The default voice model and character behavior are not defined.

# What
<!-- What changes are being made? -->

- Add INSTRUCTIONS.md
- Include the contents of INSTRUCTIONS.md in the instructions of the MCP Server's initialize method
- VOICEVOX_MCP_INSTRUCTIONS: Files can be specified via environment variables.