### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/branch-restrictions.yml
+++ b/.github/workflows/branch-restrictions.yml
@@ -1,5 +1,8 @@
 name: Branch Restrictions
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/usabarashi/voicevox-cli/security/code-scanning/1](https://github.com/usabarashi/voicevox-cli/security/code-scanning/1)

To fix the problem, an explicit permissions block should be added to the workflow. As there appears to be no need for write access to any resources, specifying `permissions: contents: read` at the workflow root (top-level, after `name:` and before or after `on:`/`env:`) will restrict the GITHUB_TOKEN permissions to read-only for repository contents and deny access to other scopes. No further changes are required elsewhere in the workflow as the job does not need elevated privileges. The fix should be added at the top level of `.github/workflows/branch-restrictions.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
