### PR TITLE
Remove audio data from MCP text_to_speech response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2903,7 +2903,6 @@ name = "voicevox-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
  "bincode",
  "clap",
  "compact_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ tempfile = "3.26"
 
 # MCP Server dependencies
 
-base64 = "0.22"
 rodio = { version = "0.22", default-features = false, features = ["playback", "wav"] }
 
 tokio = { version = "1.47", default-features = false, features = [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.89.0"
-components = ["rustfmt", "clippy", "rust-src", "rust-analyzer"]
-profile = "default"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.89.0"
-components = ["rustfmt", "clippy"]
-profile = "minimal"
+components = ["rustfmt", "clippy", "rust-src", "rust-analyzer"]
+profile = "default"

--- a/src/interface/mcp_server/tools/list.rs
+++ b/src/interface/mcp_server/tools/list.rs
@@ -30,7 +30,7 @@ pub fn get_tool_definitions() -> Vec<ToolDefinition> {
     vec![
         ToolDefinition {
             name: "text_to_speech".to_string(),
-            description: "Synthesize Japanese text to speech with VOICEVOX. Returns base64-encoded WAV audio data for client-side playback.".to_string(),
+            description: "Synthesize Japanese text to speech with VOICEVOX. Plays audio server-side and returns a text summary.".to_string(),
             input_schema: ToolInputSchema {
                 schema_type: "object".to_string(),
                 properties: json_object(json!({

--- a/src/interface/mcp_server/tools/list.rs
+++ b/src/interface/mcp_server/tools/list.rs
@@ -30,7 +30,7 @@ pub fn get_tool_definitions() -> Vec<ToolDefinition> {
     vec![
         ToolDefinition {
             name: "text_to_speech".to_string(),
-            description: "Synthesize Japanese text to speech with VOICEVOX. Plays audio server-side and returns a text summary.".to_string(),
+            description: "Synthesize Japanese text to speech with VOICEVOX. Plays audio server-side.".to_string(),
             input_schema: ToolInputSchema {
                 schema_type: "object".to_string(),
                 properties: json_object(json!({

--- a/src/interface/mcp_server/tools/text_to_speech.rs
+++ b/src/interface/mcp_server/tools/text_to_speech.rs
@@ -5,11 +5,11 @@ use std::time::Duration;
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 
-use super::types::{ToolCallResult, audio_result, text_result};
+use super::types::{ToolCallResult, success_result, text_result};
 use crate::domain::synthesis::wav::concatenate_wav_segments;
 use crate::domain::synthesis::{TextSynthesisRequest, validate_basic_request};
 use crate::domain::text_to_speech::{
-    SynthesizeParams, default_rate, default_streaming, text_char_count, validate_style_id,
+    SynthesizeParams, default_rate, default_streaming, validate_style_id,
 };
 use crate::infrastructure::daemon::startup;
 use crate::interface::mcp_server::daemon_error::{
@@ -72,8 +72,6 @@ pub async fn handle_text_to_speech(arguments: Value) -> Result<ToolCallResult> {
 
 /// Executes the `text_to_speech` tool with optional cancellation support.
 ///
-/// Returns base64-encoded WAV audio data for client-side playback.
-///
 /// # Errors
 ///
 /// Returns an error if parameters are invalid or synthesis fails.
@@ -126,7 +124,6 @@ async fn handle_streaming_synthesis(
         rate,
         streaming: _,
     } = params;
-    let text_len = text_char_count(&text);
     let synthesis = do_streaming_synthesis(&text, style_id, rate);
 
     if let Some(mut cancel_rx) = cancel_rx {
@@ -142,17 +139,11 @@ async fn handle_streaming_synthesis(
         if let Some(cancelled_result) = play_generated_audio(&wav_data, Some(cancel_rx)).await? {
             return Ok(cancelled_result);
         }
-        Ok(audio_result(
-            synthesis_success_message(text_len, style_id),
-            &wav_data,
-        ))
+        Ok(success_result())
     } else {
         let wav_data = synthesis.await?;
         play_generated_audio(&wav_data, None).await?;
-        Ok(audio_result(
-            synthesis_success_message(text_len, style_id),
-            &wav_data,
-        ))
+        Ok(success_result())
     }
 }
 
@@ -231,15 +222,11 @@ async fn handle_daemon_synthesis(
         ));
     };
 
-    let text_len = text_char_count(&text);
     if let Some(cancelled_result) = play_generated_audio(&wav_data, cancel_rx).await? {
         return Ok(cancelled_result);
     }
 
-    Ok(audio_result(
-        synthesis_success_message(text_len, style_id),
-        &wav_data,
-    ))
+    Ok(success_result())
 }
 
 #[allow(clippy::future_not_send)]
@@ -310,9 +297,6 @@ async fn run_daemon_retry_phase(
     }
 }
 
-fn synthesis_success_message(text_len: usize, style_id: u32) -> String {
-    format!("Synthesized {text_len} characters using style ID {style_id}")
-}
 
 fn cancellation_message(reason: &str) -> String {
     if reason.is_empty() {

--- a/src/interface/mcp_server/tools/text_to_speech.rs
+++ b/src/interface/mcp_server/tools/text_to_speech.rs
@@ -297,7 +297,6 @@ async fn run_daemon_retry_phase(
     }
 }
 
-
 fn cancellation_message(reason: &str) -> String {
     if reason.is_empty() {
         "Synthesis cancelled".to_string()

--- a/src/interface/mcp_server/tools/types.rs
+++ b/src/interface/mcp_server/tools/types.rs
@@ -1,4 +1,3 @@
-use base64::Engine;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -13,23 +12,10 @@ pub struct ToolCallResult {
 pub enum ToolContent {
     #[serde(rename = "text")]
     Text { text: String },
-    #[serde(rename = "audio")]
-    Audio {
-        data: String,
-        #[serde(rename = "mimeType")]
-        mime_type: String,
-    },
 }
 
 fn text_content(text: impl Into<String>) -> ToolContent {
     ToolContent::Text { text: text.into() }
-}
-
-fn audio_content(wav_data: &[u8]) -> ToolContent {
-    ToolContent::Audio {
-        data: base64::engine::general_purpose::STANDARD.encode(wav_data),
-        mime_type: "audio/wav".to_string(),
-    }
 }
 
 pub(crate) fn text_result(text: impl Into<String>, is_error: bool) -> ToolCallResult {
@@ -39,26 +25,9 @@ pub(crate) fn text_result(text: impl Into<String>, is_error: bool) -> ToolCallRe
     }
 }
 
-pub(crate) fn audio_result(summary: impl Into<String>, wav_data: &[u8]) -> ToolCallResult {
+pub(crate) fn success_result() -> ToolCallResult {
     ToolCallResult {
-        content: vec![text_content(summary), audio_content(wav_data)],
+        content: vec![text_content("ok")],
         is_error: None,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn audio_result_uses_audio_content_shape() {
-        let result = audio_result("ok", b"RIFF");
-        let value = serde_json::to_value(result).expect("tool result should serialize");
-
-        assert_eq!(value["content"][0], json!({"type": "text", "text": "ok"}));
-        assert_eq!(value["content"][1]["type"], "audio");
-        assert_eq!(value["content"][1]["mimeType"], "audio/wav");
-        assert!(value["content"][1]["data"].as_str().is_some());
     }
 }

--- a/src/interface/mcp_server/tools/types.rs
+++ b/src/interface/mcp_server/tools/types.rs
@@ -31,3 +31,27 @@ pub(crate) fn success_result() -> ToolCallResult {
         is_error: None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn success_result_serializes_to_expected_json() {
+        let result = success_result();
+
+        let json = serde_json::to_value(&result).unwrap();
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "ok"
+                    }
+                ]
+            })
+        );
+    }
+}


### PR DESCRIPTION
  ## Why

  AI agents cannot use base64-encoded WAV binary data returned in the MCP tool response -- it only wastes tokens. The server already plays audio locally as a side effect, so returning the audio payload provides no value to the caller.

  ## What

  - Remove `ToolContent::Audio` variant and `audio_result()` / `audio_content()` helpers
  - Replace with minimal `success_result()` returning fixed `"ok"` text
  - Drop `base64` crate dependency
  - Remove `synthesis_success_message()` and unused `text_char_count` import
  - Update tool description to reflect server-side playback behavior



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Text-to-speech tool now plays audio on the server side instead of returning audio files for client-side playback. The tool returns a text confirmation of the synthesis operation instead, shifting all audio processing to occur server-side. This streamlines the workflow and simplifies integration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->