### PR TITLE
Migrate Nix flake from buildRustPackage to crane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   actions: write

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1775839657,
+        "narHash": "sha256-SPm9ck7jh3Un9nwPuMGbRU04UroFmOHjLP56T10MOeM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "7cf72d978629469c4bd4206b95c402514c1f6000",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "fenix": {
       "inputs": {
         "nixpkgs": [
@@ -57,6 +72,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "fenix": "fenix",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
       url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    crane.url = "github:ipetkov/crane";
   };
 
   outputs =
@@ -28,6 +29,7 @@
       nixpkgs,
       flake-utils,
       fenix,
+      crane,
     }:
     let
       systems = [ "aarch64-darwin" ];
@@ -40,22 +42,23 @@
         cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
         version = cargoToml.package.version;
 
-        # Fenix stable toolchain used for local builds/checks
+        # Fenix stable toolchain
         rustToolchain = fenix.packages.${system}.stable;
 
-        # Shared cargo lock configuration (used by build and checks)
-        cargoLockConfig = {
-          lockFile = ./Cargo.lock;
-          outputHashes = {
-            "open_jtalk-0.1.25" = "sha256-sdUWHHY+eY3bWMGSPu/+0jGz1f4HMHq3D17Tzbwt0Nc=";
-            "voicevox_core-0.0.0" = "sha256-tQ1NQm1e+boCG6SAu1Qr7PeCqJFOU0wIG2VtWQVwUA0=";
-            "voicevox-ort-2.0.0-rc.10" = "sha256-BsgE3v8eir+IkrPw2rYrhen/s63GHnI4Na0N2c2lHVg=";
-          };
-        };
+        # Minimal toolchain for builds and checks (no rust-src/rust-docs)
+        buildToolchain = fenix.packages.${system}.combine [
+          rustToolchain.rustc
+          rustToolchain.cargo
+          rustToolchain.rustfmt
+          rustToolchain.clippy
+        ];
 
-        # Shared source filter
-        srcFiltered = lib.cleanSourceWith {
-          src = ./.;
+        # Crane library with minimal fenix toolchain
+        craneLib = (crane.mkLib pkgs).overrideToolchain buildToolchain;
+
+        # Source filtering
+        src = lib.cleanSourceWith {
+          src = craneLib.cleanCargoSource ./.;
           filter =
             path: type:
             let
@@ -67,19 +70,6 @@
             );
         };
 
-        # Shared native build inputs for Rust compilation
-        commonNativeBuildInputs = with pkgs; [
-          rustToolchain.defaultToolchain
-          pkg-config
-          cmake
-          gnumake
-          autoconf
-          automake
-          libtool
-          git
-          cacert
-        ];
-
         # ONNX Runtime library search path for build.rs (voicevox-ort-sys).
         # Actual library is loaded at runtime via dlopen (load-dynamic),
         # so only the path needs to exist at build time.
@@ -87,13 +77,89 @@
           mkdir -p $out/lib
         '';
 
+        # Vendor cargo dependencies with git dependency hashes
+        cargoVendorDir = craneLib.vendorCargoDeps {
+          src = ./.;
+          outputHashes = {
+            "open_jtalk-0.1.25" = "sha256-sdUWHHY+eY3bWMGSPu/+0jGz1f4HMHq3D17Tzbwt0Nc=";
+            "voicevox_core-0.0.0" = "sha256-tQ1NQm1e+boCG6SAu1Qr7PeCqJFOU0wIG2VtWQVwUA0=";
+            "voicevox-ort-2.0.0-rc.10" = "sha256-BsgE3v8eir+IkrPw2rYrhen/s63GHnI4Na0N2c2lHVg=";
+          };
+          overrideVendorGitCheckout =
+            ps: drv:
+            # VOICEVOX/ort is a workspace with excluded members (backends,
+            # examples, tests) whose Cargo.toml files confuse crane's
+            # package discovery. Vendor the two needed crates manually.
+            if lib.any (p: p.name == "voicevox-ort") ps then
+              let
+                pkg = name: (lib.findFirst (p: p.name == name) null ps);
+                dir = p: "${p.name}-${p.version}";
+              in
+              drv.overrideAttrs {
+                installPhase =
+                  let
+                    ort = dir (pkg "voicevox-ort");
+                    sys = dir (pkg "voicevox-ort-sys");
+                  in
+                  ''
+                    mkdir -p $out
+
+                    # Root crate (copy without workspace members)
+                    cp -r . $out/${ort}
+                    rm -rf $out/${ort}/{ort-sys,backends,examples,tests}
+                    echo '{"files":{}}' > $out/${ort}/.cargo-checksum.json
+
+                    # ort-sys sub-crate
+                    cp -r ort-sys $out/${sys}
+                    echo '{"files":{}}' > $out/${sys}/.cargo-checksum.json
+                  '';
+              }
+            else
+              drv;
+        };
+
+        # Shared build arguments for all crane derivations
+        commonArgs = {
+          inherit src cargoVendorDir version;
+          pname = "voicevox-cli";
+          strictDeps = true;
+          doCheck = false;
+          cargoExtraArgs = "--locked --all-features";
+
+          CARGO_NET_OFFLINE = true;
+          ORT_LIB_LOCATION = "${onnxruntimeLibDir}";
+
+          preConfigure = ''
+            export HOME=$PWD/build-home
+            mkdir -p $HOME
+          '';
+
+          preBuild = ''
+            export GIT_SSL_CAINFO="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+            export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+          '';
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            cmake
+            gnumake
+            autoconf
+            automake
+            libtool
+            git
+            cacert
+          ];
+        };
+
+        # Build only cargo dependencies (shared by build, clippy, tests)
+        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
         # Voice models and resources downloader
         voicevoxDownloader = pkgs.fetchurl {
           url = "https://github.com/VOICEVOX/voicevox_core/releases/download/0.16.3/download-osx-arm64";
           hash = "sha256-7GMosxM4HRDAix6BImNP5Q5PNpWJYEvMLNApKjNht+k=";
         };
 
-        # Simple resources for voicevox-download binary
         voicevoxResources = pkgs.stdenv.mkDerivation {
           name = "voicevox-resources";
 
@@ -116,59 +182,21 @@
           platforms = systems;
         };
 
-        mkRustPackage =
-          extraAttrs:
-          pkgs.rustPlatform.buildRustPackage (
-            {
-              inherit version;
+        # Final package
+        voicevoxCli = craneLib.buildPackage (
+          commonArgs
+          // {
+            inherit cargoArtifacts;
 
-              src = srcFiltered;
-              cargoLock = cargoLockConfig;
+            postInstall = ''
+              cp ${voicevoxResources}/bin/voicevox-download $out/bin/
+              install -m755 ${./scripts/voicevox-setup.sh} $out/bin/voicevox-setup
+              install -m644 ${./VOICEVOX.md} $out/bin/VOICEVOX.md
+            '';
 
-              doCheck = false;
-
-              # Force offline mode to ensure reproducible builds
-              CARGO_NET_OFFLINE = true;
-
-              # ONNX Runtime library search path (actual library loaded at runtime via dlopen)
-              ORT_LIB_LOCATION = "${onnxruntimeLibDir}";
-
-              # Minimal pre-configure setup
-              preConfigure = ''
-                # Create a temporary HOME for build process
-                export HOME=$PWD/build-home
-                mkdir -p $HOME
-              '';
-
-              nativeBuildInputs = commonNativeBuildInputs;
-
-              # Build-time environment variables
-              preBuild = ''
-                # Git SSL configuration
-                export GIT_SSL_CAINFO="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
-                export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
-              '';
-
-              meta = packageMeta;
-            }
-            // extraAttrs
-          );
-
-        voicevoxCli = mkRustPackage {
-          pname = "voicevox-cli";
-
-          postInstall = ''
-            # Install download utility
-            cp ${voicevoxResources}/bin/voicevox-download $out/bin/
-
-            # Install setup script
-            install -m755 ${./scripts/voicevox-setup.sh} $out/bin/voicevox-setup
-
-            # Install VOICEVOX.md for MCP server
-            install -m644 ${./VOICEVOX.md} $out/bin/VOICEVOX.md
-          '';
-
-        };
+            meta = packageMeta;
+          }
+        );
 
         # Development utility: reset daemon state
         voicevoxResetWrapper = pkgs.writeShellScriptBin "voicevox-reset" (
@@ -196,19 +224,10 @@
         };
 
         checks = {
-          # Code formatting check
-          formatting =
-            pkgs.runCommand "check-formatting"
-              {
-                nativeBuildInputs = [ rustToolchain.defaultToolchain ];
-                src = srcFiltered;
-              }
-              ''
-                cd $src
-                export HOME=$TMPDIR
-                cargo fmt --all --check
-                touch $out
-              '';
+          # Code formatting
+          formatting = craneLib.cargoFmt {
+            inherit src;
+          };
 
           # Shell script syntax validation
           scripts =
@@ -219,7 +238,16 @@
                   gnused
                   gnugrep
                 ];
-                src = srcFiltered;
+                src = lib.cleanSourceWith {
+                  src = ./.;
+                  filter =
+                    path: type:
+                    let
+                      baseName = baseNameOf path;
+                    in
+                    (type == "directory" && baseName == "scripts")
+                    || (type == "regular" && lib.hasSuffix ".sh" baseName);
+                };
               }
               ''
                 test -f $src/scripts/voicevox-setup.sh || (echo "Missing voicevox-setup.sh" && exit 1)
@@ -240,48 +268,35 @@
           # Build verification
           build = voicevoxCli;
 
-          # Static analysis (kept separate from package build for clearer check/package responsibilities)
-          clippy = mkRustPackage {
-            pname = "voicevox-cli-clippy";
+          # Static analysis (reuses cargoArtifacts)
+          clippy = craneLib.cargoClippy (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              cargoClippyExtraArgs = "--all-targets -- -D warnings";
+            }
+          );
 
-            buildPhase = ''
-              runHook preBuild
-              cargo clippy --release --all-targets --all-features -- -D warnings
-              runHook postBuild
-            '';
-
-            installPhase = ''
-              mkdir -p $out
-            '';
-          };
-
-          # Test suite verification
-          tests = mkRustPackage {
-            pname = "voicevox-cli-tests";
-
-            buildPhase = ''
-              runHook preBuild
-              cargo test --release --all-targets --all-features
-              runHook postBuild
-            '';
-
-            installPhase = ''
-              mkdir -p $out
-            '';
-          };
+          # Test suite (reuses cargoArtifacts)
+          tests = craneLib.cargoTest (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+            }
+          );
         };
 
         apps = appAttrs // {
           default = appAttrs.voicevox-say;
         };
 
-        devShells.default = pkgs.mkShell {
+        devShells.default = craneLib.devShell {
+          checks = self.checks.${system};
+
           # ONNX Runtime library search path (actual library loaded at runtime via dlopen)
           ORT_LIB_LOCATION = "${onnxruntimeLibDir}";
 
           packages = with pkgs; [
-            # Use fenix-provided rust toolchain that matches rust-toolchain.toml
-            rustToolchain.defaultToolchain
             rustToolchain.rust-analyzer
             cargo-audit
 

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
             in
             !(
               (type == "directory" && lib.hasSuffix "-extract" baseName)
-              || (type == "regular" && lib.hasSuffix ".tar.gz" baseName && baseName != "Cargo.lock")
+              || (type == "regular" && lib.hasSuffix ".tar.gz" baseName)
             );
         };
 
@@ -79,7 +79,7 @@
 
         # Vendor cargo dependencies with git dependency hashes
         cargoVendorDir = craneLib.vendorCargoDeps {
-          src = ./.;
+          inherit src;
           outputHashes = {
             "open_jtalk-0.1.25" = "sha256-sdUWHHY+eY3bWMGSPu/+0jGz1f4HMHq3D17Tzbwt0Nc=";
             "voicevox_core-0.0.0" = "sha256-tQ1NQm1e+boCG6SAu1Qr7PeCqJFOU0wIG2VtWQVwUA0=";
@@ -94,12 +94,15 @@
               let
                 pkg = name: (lib.findFirst (p: p.name == name) null ps);
                 dir = p: "${p.name}-${p.version}";
+                ortPkg = pkg "voicevox-ort";
+                sysPkg = pkg "voicevox-ort-sys";
               in
+              assert ortPkg != null && sysPkg != null;
               drv.overrideAttrs {
                 installPhase =
                   let
-                    ort = dir (pkg "voicevox-ort");
-                    sys = dir (pkg "voicevox-ort-sys");
+                    ort = dir ortPkg;
+                    sys = dir sysPkg;
                   in
                   ''
                     mkdir -p $out
@@ -282,6 +285,7 @@
             commonArgs
             // {
               inherit cargoArtifacts;
+              doCheck = true;
             }
           );
         };


### PR DESCRIPTION
  ## Why

  CI compiled the codebase 3 times independently (build, clippy, tests) because each `buildRustPackage` derivation had no shared compilation artifacts. Migrating to crane's `buildDepsOnly` pattern lets all checks share a single dependency build, significantly reducing CI time.

  ## What

  - Add crane input, create `craneLib` with minimal fenix toolchain (rustc, cargo, rustfmt, clippy)
  - Replace `mkRustPackage` / `buildRustPackage` with crane's `buildDepsOnly` + `buildPackage`
  - Share `cargoArtifacts` across `buildPackage`, `cargoClippy`, and `cargoTest`
  - Use `overrideVendorGitCheckout` to handle VOICEVOX/ort workspace vendoring (no sed/regex, dynamic versions)
  - Unify feature flags with `--locked --all-features` across all derivations
  - Switch formatting check to `craneLib.cargoFmt`
  - Switch devShell to `craneLib.devShell`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored build system infrastructure for improved development efficiency
  * Enhanced CI checks and development environment setup
  * Updated build tooling and dependency management processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->