### PR TITLE
migrate IPC serialization from bincode to postcard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,26 +207,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
-]
 
 [[package]]
 name = "bindgen"
@@ -307,6 +296,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -439,6 +434,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -581,6 +585,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -783,6 +793,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
@@ -1008,6 +1030,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1058,20 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -1272,6 +1317,15 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1763,6 +1817,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,6 +2006,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,6 +2071,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -2148,6 +2230,21 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -2552,12 +2649,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,23 +2673,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
-
-[[package]]
 name = "voicevox-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bincode",
  "clap",
  "compact_str",
  "dirs",
  "futures-util",
  "libc",
  "mimalloc",
+ "postcard",
  "rayon",
  "rodio",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ clap = { version = "4.6", features = ["derive", "unicode", "wrap_help"] }
 
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
-bincode = { version = "2.0", features = ["serde"] }
+postcard = { version = "1.1", features = ["alloc"] }
 dirs = "6.0"
 tempfile = "3.27"
 

--- a/src/infrastructure/daemon/client/transport.rs
+++ b/src/infrastructure/daemon/client/transport.rs
@@ -16,14 +16,11 @@ pub(crate) const DAEMON_CONNECTION_TIMEOUT: Duration = Duration::from_secs(2);
 pub(crate) const DAEMON_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn encode_request_frame(request: &OwnedRequest) -> Result<Vec<u8>> {
-    bincode::serde::encode_to_vec(request, bincode::config::standard())
-        .map_err(|e| anyhow!("Failed to serialize request: {e}"))
+    postcard::to_allocvec(request).map_err(|e| anyhow!("Failed to serialize request: {e}"))
 }
 
 fn decode_response_frame(frame: &[u8]) -> Result<OwnedResponse> {
-    bincode::serde::decode_from_slice(frame, bincode::config::standard())
-        .map(|(response, _)| response)
-        .map_err(|e| anyhow!("Failed to deserialize response: {e}"))
+    postcard::from_bytes(frame).map_err(|e| anyhow!("Failed to deserialize response: {e}"))
 }
 
 fn current_uid() -> u32 {

--- a/src/infrastructure/daemon/server.rs
+++ b/src/infrastructure/daemon/server.rs
@@ -61,13 +61,11 @@ fn remove_socket_if_exists(socket_path: &Path) -> Result<()> {
 }
 
 fn decode_request_frame(data: &[u8]) -> Result<DaemonRequest> {
-    bincode::serde::decode_from_slice::<DaemonRequest, _>(data, bincode::config::standard())
-        .map(|(request, _)| request)
-        .map_err(Into::into)
+    postcard::from_bytes(data).map_err(Into::into)
 }
 
 fn encode_response_frame(response: &OwnedResponse) -> Result<Vec<u8>> {
-    bincode::serde::encode_to_vec(response, bincode::config::standard()).map_err(Into::into)
+    postcard::to_allocvec(response).map_err(Into::into)
 }
 
 fn log_client_error(context: &str, error: &dyn std::fmt::Display) {

--- a/src/infrastructure/ipc/protocol.rs
+++ b/src/infrastructure/ipc/protocol.rs
@@ -3,15 +3,15 @@ use std::collections::HashMap;
 
 use super::DEFAULT_SYNTHESIS_RATE;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct IpcStyle {
     pub name: String,
     pub id: u32,
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type")]
     pub style_type: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct IpcSpeaker {
     pub name: String,
     #[serde(default)]
@@ -21,7 +21,7 @@ pub struct IpcSpeaker {
     pub version: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct IpcModel {
     pub model_id: u32,
     pub file_path: std::path::PathBuf,
@@ -29,7 +29,7 @@ pub struct IpcModel {
 }
 
 /// Request messages sent from client to daemon.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum DaemonRequest {
     Synthesize {
         text: String,
@@ -41,7 +41,7 @@ pub enum DaemonRequest {
 }
 
 /// Synthesis options for voice synthesis requests.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq)]
 pub struct SynthesizeOptions {
     pub rate: f32,
 }
@@ -55,7 +55,7 @@ impl Default for SynthesizeOptions {
 }
 
 /// Response messages from daemon to client.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub enum DaemonResponse {
     SynthesizeResult {
         wav_data: Vec<u8>,
@@ -89,3 +89,106 @@ pub type OwnedResponse = DaemonResponse;
 
 /// Synthesis options for owned data.
 pub type OwnedSynthesizeOptions = SynthesizeOptions;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn roundtrip_request(request: &DaemonRequest) -> DaemonRequest {
+        let encoded = postcard::to_allocvec(request).expect("encode request");
+        postcard::from_bytes(&encoded).expect("decode request")
+    }
+
+    fn roundtrip_response(response: &DaemonResponse) -> DaemonResponse {
+        let encoded = postcard::to_allocvec(response).expect("encode response");
+        postcard::from_bytes(&encoded).expect("decode response")
+    }
+
+    #[test]
+    fn synthesize_request_roundtrip() {
+        let request = DaemonRequest::Synthesize {
+            text: "これはテストです".to_string(),
+            style_id: 3,
+            options: SynthesizeOptions { rate: 1.2 },
+        };
+        assert_eq!(roundtrip_request(&request), request);
+    }
+
+    #[test]
+    fn unit_variant_requests_roundtrip() {
+        assert_eq!(
+            roundtrip_request(&DaemonRequest::ListSpeakers),
+            DaemonRequest::ListSpeakers
+        );
+        assert_eq!(
+            roundtrip_request(&DaemonRequest::ListModels),
+            DaemonRequest::ListModels
+        );
+    }
+
+    #[test]
+    fn synthesize_result_preserves_wav_bytes() {
+        let wav_data: Vec<u8> = (0..65536).map(|i| (i % 256) as u8).collect();
+        let response = DaemonResponse::SynthesizeResult {
+            wav_data: wav_data.clone(),
+        };
+        let decoded = roundtrip_response(&response);
+        assert_eq!(decoded, response);
+        if let DaemonResponse::SynthesizeResult {
+            wav_data: decoded_wav,
+        } = decoded
+        {
+            assert_eq!(decoded_wav.len(), 65536);
+            assert_eq!(decoded_wav, wav_data);
+        } else {
+            panic!("expected SynthesizeResult");
+        }
+    }
+
+    #[test]
+    fn speakers_list_with_models_roundtrip() {
+        let response = DaemonResponse::SpeakersListWithModels {
+            speakers: vec![IpcSpeaker {
+                name: "ずんだもん".to_string(),
+                speaker_uuid: "uuid-1234".to_string(),
+                styles: vec![
+                    IpcStyle {
+                        name: "ノーマル".to_string(),
+                        id: 3,
+                        style_type: Some("talk".to_string()),
+                    },
+                    IpcStyle {
+                        name: "あまあま".to_string(),
+                        id: 1,
+                        style_type: None,
+                    },
+                ],
+                version: "0.1.0".to_string(),
+            }],
+            style_to_model: HashMap::from([(3, 0), (1, 0)]),
+        };
+        assert_eq!(roundtrip_response(&response), response);
+    }
+
+    #[test]
+    fn models_list_roundtrip() {
+        let response = DaemonResponse::ModelsList {
+            models: vec![IpcModel {
+                model_id: 0,
+                file_path: PathBuf::from("/path/to/0.vvm"),
+                speakers: vec![],
+            }],
+        };
+        assert_eq!(roundtrip_response(&response), response);
+    }
+
+    #[test]
+    fn error_response_roundtrip() {
+        let response = DaemonResponse::Error {
+            code: DaemonErrorCode::SynthesisFailed,
+            message: "synthesis error".to_string(),
+        };
+        assert_eq!(roundtrip_response(&response), response);
+    }
+}


### PR DESCRIPTION
  ## Why

  bincode v3.0.0 is an intentionally broken release due to the project being unmaintained (RUSTSEC-2025-0141). postcard is the RUSTSEC-recommended replacement: stable (v1.0+), actively maintained, and serde-compatible.

  ## What

  - Replace `bincode` with `postcard` in `Cargo.toml`
  - Rewrite daemon/client encode/decode functions to use `postcard::to_allocvec` / `postcard::from_bytes`
  - Remove `#[serde(skip_serializing_if)]` from `IpcStyle.style_type` (incompatible with postcard's non-self-describing wire       
  format)
  - Add `PartialEq` derives to all IPC protocol types
  - Add 6 roundtrip serialization tests covering all `DaemonRequest` / `DaemonResponse` variants

  ## References

  - #130 (Renovate PR for bincode v3, closed — v3 is unusable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated internal serialization mechanism for daemon and inter-process communication components.
  * Added equality comparison support to core data structures.

* **Tests**
  * Introduced comprehensive serialization roundtrip tests to validate data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->