### PR TITLE
Fix daemon synthesis responses and release idle Core memory

### DIFF
--- a/src/infrastructure/core.rs
+++ b/src/infrastructure/core.rs
@@ -142,11 +142,13 @@ impl VoicevoxCore {
     ///
     /// Returns an error if the model file cannot be opened or the core fails to unload it.
     pub fn unload_voice_model_by_path(&self, model_path: &Path) -> Result<()> {
-        let model = open_voice_model_file(model_path)?;
-        let voice_model_id = model.id();
+        let voice_model_id = open_voice_model_file(model_path)?.id();
 
         self.synthesizer
             .unload_voice_model(voice_model_id)
-            .map_err(|e| anyhow!("Failed to unload model: {e}"))
+            .map_err(|e| anyhow!("Failed to unload model: {e}"))?;
+
+        crate::infrastructure::memory::release_unused_allocator_memory();
+        Ok(())
     }
 }

--- a/src/infrastructure/daemon/server.rs
+++ b/src/infrastructure/daemon/server.rs
@@ -11,7 +11,9 @@ use tokio::time::timeout;
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 
 use crate::infrastructure::daemon::state::DaemonState;
-use crate::infrastructure::ipc::{DaemonRequest, MAX_DAEMON_REQUEST_FRAME_BYTES, OwnedResponse};
+use crate::infrastructure::ipc::{
+    DaemonRequest, MAX_DAEMON_REQUEST_FRAME_BYTES, MAX_DAEMON_RESPONSE_FRAME_BYTES, OwnedResponse,
+};
 
 const SOCKET_DIR_MODE: u32 = 0o700;
 const SOCKET_FILE_MODE: u32 = 0o600;
@@ -116,7 +118,7 @@ async fn handle_client_with_limit(
     permits: Arc<Semaphore>,
 ) -> Result<()> {
     let codec = LengthDelimitedCodec::builder()
-        .max_frame_length(MAX_DAEMON_REQUEST_FRAME_BYTES)
+        .max_frame_length(MAX_DAEMON_REQUEST_FRAME_BYTES.max(MAX_DAEMON_RESPONSE_FRAME_BYTES))
         .new_codec();
     let mut framed = Framed::new(stream, codec);
 

--- a/src/infrastructure/daemon/server.rs
+++ b/src/infrastructure/daemon/server.rs
@@ -8,7 +8,7 @@ use tokio::net::{UnixListener, UnixStream};
 use tokio::signal;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::time::timeout;
-use tokio_util::codec::{Framed, LengthDelimitedCodec};
+use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
 
 use crate::infrastructure::daemon::state::DaemonState;
 use crate::infrastructure::ipc::{
@@ -117,12 +117,17 @@ async fn handle_client_with_limit(
     state: Arc<DaemonState>,
     permits: Arc<Semaphore>,
 ) -> Result<()> {
-    let codec = LengthDelimitedCodec::builder()
-        .max_frame_length(MAX_DAEMON_REQUEST_FRAME_BYTES.max(MAX_DAEMON_RESPONSE_FRAME_BYTES))
+    let request_codec = LengthDelimitedCodec::builder()
+        .max_frame_length(MAX_DAEMON_REQUEST_FRAME_BYTES)
         .new_codec();
-    let mut framed = Framed::new(stream, codec);
+    let response_codec = LengthDelimitedCodec::builder()
+        .max_frame_length(MAX_DAEMON_RESPONSE_FRAME_BYTES)
+        .new_codec();
+    let (reader, writer) = stream.into_split();
+    let mut framed_read = FramedRead::new(reader, request_codec);
+    let mut framed_write = FramedWrite::new(writer, response_codec);
 
-    while let Some(frame) = timeout(CLIENT_IDLE_TIMEOUT, framed.next())
+    while let Some(frame) = timeout(CLIENT_IDLE_TIMEOUT, framed_read.next())
         .await
         .map_err(|_| anyhow!("Client idle timeout"))?
     {
@@ -150,7 +155,7 @@ async fn handle_client_with_limit(
             break;
         };
 
-        if let Err(error) = framed.send(response_data.into()).await {
+        if let Err(error) = framed_write.send(response_data.into()).await {
             log_client_error("Client stream write error", &error);
             break;
         }

--- a/src/infrastructure/daemon/state.rs
+++ b/src/infrastructure/daemon/state.rs
@@ -52,9 +52,12 @@ impl DaemonState {
     /// Returns an error if VOICEVOX core initialization fails, model discovery fails,
     /// or the style-to-model mapping cannot be constructed.
     pub fn new() -> Result<Self> {
-        let core = crate::infrastructure::core::VoicevoxCore::new()?;
-        let catalog = ModelCatalog::new(&core)?;
-        let synthesis_executor = DaemonSynthesisExecutor::new(core);
+        let catalog_core = crate::infrastructure::core::VoicevoxCore::new()?;
+        let catalog = ModelCatalog::new(&catalog_core)?;
+        drop(catalog_core);
+        crate::infrastructure::memory::release_unused_allocator_memory();
+
+        let synthesis_executor = DaemonSynthesisExecutor::new();
         let synthesis_policy = SerializedSynthesisPolicy::new(synthesis_executor);
 
         Ok(Self {

--- a/src/infrastructure/daemon/state/executor.rs
+++ b/src/infrastructure/daemon/state/executor.rs
@@ -6,7 +6,7 @@ use super::catalog::{ModelCatalog, TargetResolution};
 use super::result::{DaemonServiceError, DaemonServiceErrorKind, DaemonServiceResult};
 
 pub(super) struct DaemonSynthesisExecutor {
-    core: VoicevoxCore,
+    core: Option<VoicevoxCore>,
 }
 
 /// RAII guard that unloads a voice model on drop.
@@ -40,12 +40,30 @@ impl Drop for ModelUnloadGuard<'_> {
 }
 
 impl DaemonSynthesisExecutor {
-    pub(super) fn new(core: VoicevoxCore) -> Self {
-        Self { core }
+    pub(super) fn new() -> Self {
+        Self { core: None }
+    }
+
+    fn ensure_core(&mut self) -> Result<(), DaemonServiceError> {
+        if self.core.is_none() {
+            self.core = Some(VoicevoxCore::new().map_err(|error| {
+                DaemonServiceError::new(
+                    DaemonServiceErrorKind::ModelLoadFailed,
+                    format!("Failed to initialize VOICEVOX core for synthesis: {error}"),
+                )
+            })?);
+        }
+
+        Ok(())
+    }
+
+    fn release_core(&mut self) {
+        self.core = None;
+        crate::infrastructure::memory::release_unused_allocator_memory();
     }
 
     pub(super) fn synthesize(
-        &self,
+        &mut self,
         catalog: &ModelCatalog,
         text: String,
         requested_id: u32,
@@ -62,26 +80,38 @@ impl DaemonSynthesisExecutor {
         };
         let model_path = catalog.get_model_path(model_id);
 
-        if let Err(error) = self.core.load_specific_model(model_id) {
+        self.ensure_core()?;
+
+        let core = self
+            .core
+            .as_ref()
+            .expect("core must be initialized by ensure_core");
+
+        if let Err(error) = core.load_specific_model(model_id) {
             crate::infrastructure::logging::error(&format!(
                 "Failed to load model {model_id}: {error}"
             ));
+            self.release_core();
             return Err(DaemonServiceError::new(
                 DaemonServiceErrorKind::ModelLoadFailed,
                 format!("Failed to load model {model_id} for synthesis: {error}"),
             ));
         }
 
-        // RAII guard ensures the model is always unloaded, even on panic or
-        // task cancellation. Matches DaemonRequestHandling.tla ClientDisconnect:
-        //   mutex_holder = c => model_loaded' = FALSE
-        let _model_guard = ModelUnloadGuard {
-            core: &self.core,
-            model_id,
-            model_path,
+        let synthesis_result = {
+            // RAII guard ensures the model is always unloaded, even on panic or
+            // task cancellation. Matches DaemonRequestHandling.tla ClientDisconnect:
+            //   mutex_holder = c => model_loaded' = FALSE
+            let _model_guard = ModelUnloadGuard {
+                core,
+                model_id,
+                model_path,
+            };
+
+            core.synthesize_with_rate(&text, style_id, rate)
         };
 
-        let synthesis_result = self.core.synthesize_with_rate(&text, style_id, rate);
+        self.release_core();
 
         match synthesis_result {
             Ok(wav_data) => Ok(DaemonServiceResult::SynthesizeResult { wav_data }),

--- a/src/infrastructure/daemon/state/executor.rs
+++ b/src/infrastructure/daemon/state/executor.rs
@@ -5,9 +5,7 @@ use crate::infrastructure::core::VoicevoxCore;
 use super::catalog::{ModelCatalog, TargetResolution};
 use super::result::{DaemonServiceError, DaemonServiceErrorKind, DaemonServiceResult};
 
-pub(super) struct DaemonSynthesisExecutor {
-    core: Option<VoicevoxCore>,
-}
+pub(super) struct DaemonSynthesisExecutor;
 
 /// RAII guard that unloads a voice model on drop.
 ///
@@ -18,6 +16,14 @@ struct ModelUnloadGuard<'a> {
     core: &'a VoicevoxCore,
     model_id: u32,
     model_path: Option<&'a Path>,
+}
+
+struct AllocatorReliefGuard;
+
+impl Drop for AllocatorReliefGuard {
+    fn drop(&mut self) {
+        crate::infrastructure::memory::release_unused_allocator_memory();
+    }
 }
 
 impl Drop for ModelUnloadGuard<'_> {
@@ -41,25 +47,7 @@ impl Drop for ModelUnloadGuard<'_> {
 
 impl DaemonSynthesisExecutor {
     pub(super) fn new() -> Self {
-        Self { core: None }
-    }
-
-    fn ensure_core(&mut self) -> Result<(), DaemonServiceError> {
-        if self.core.is_none() {
-            self.core = Some(VoicevoxCore::new().map_err(|error| {
-                DaemonServiceError::new(
-                    DaemonServiceErrorKind::ModelLoadFailed,
-                    format!("Failed to initialize VOICEVOX core for synthesis: {error}"),
-                )
-            })?);
-        }
-
-        Ok(())
-    }
-
-    fn release_core(&mut self) {
-        self.core = None;
-        crate::infrastructure::memory::release_unused_allocator_memory();
+        Self
     }
 
     pub(super) fn synthesize(
@@ -80,18 +68,18 @@ impl DaemonSynthesisExecutor {
         };
         let model_path = catalog.get_model_path(model_id);
 
-        self.ensure_core()?;
-
-        let core = self
-            .core
-            .as_ref()
-            .expect("core must be initialized by ensure_core");
+        let _allocator_relief = AllocatorReliefGuard;
+        let core = VoicevoxCore::new().map_err(|error| {
+            DaemonServiceError::new(
+                DaemonServiceErrorKind::ModelLoadFailed,
+                format!("Failed to initialize VOICEVOX core for synthesis: {error}"),
+            )
+        })?;
 
         if let Err(error) = core.load_specific_model(model_id) {
             crate::infrastructure::logging::error(&format!(
                 "Failed to load model {model_id}: {error}"
             ));
-            self.release_core();
             return Err(DaemonServiceError::new(
                 DaemonServiceErrorKind::ModelLoadFailed,
                 format!("Failed to load model {model_id} for synthesis: {error}"),
@@ -103,15 +91,13 @@ impl DaemonSynthesisExecutor {
             // task cancellation. Matches DaemonRequestHandling.tla ClientDisconnect:
             //   mutex_holder = c => model_loaded' = FALSE
             let _model_guard = ModelUnloadGuard {
-                core,
+                core: &core,
                 model_id,
                 model_path,
             };
 
             core.synthesize_with_rate(&text, style_id, rate)
         };
-
-        self.release_core();
 
         match synthesis_result {
             Ok(wav_data) => Ok(DaemonServiceResult::SynthesizeResult { wav_data }),

--- a/src/infrastructure/daemon/state/policy.rs
+++ b/src/infrastructure/daemon/state/policy.rs
@@ -26,7 +26,7 @@ impl SerializedSynthesisPolicy {
         requested_id: u32,
         rate: f32,
     ) -> Result<DaemonServiceResult, DaemonServiceError> {
-        let executor = self.executor.lock().await;
+        let mut executor = self.executor.lock().await;
         executor.synthesize(catalog, text, requested_id, rate)
     }
 }

--- a/src/infrastructure/memory.rs
+++ b/src/infrastructure/memory.rs
@@ -1,0 +1,23 @@
+/// Asks the platform allocator to return unused process memory to the OS.
+///
+/// This is a best-effort RSS reduction hook for large native allocations released
+/// by VOICEVOX Core. The return value is the allocator-reported released byte
+/// count when the platform exposes one.
+#[cfg(target_os = "macos")]
+pub fn release_unused_allocator_memory() -> usize {
+    use libc::size_t;
+    use std::ffi::c_void;
+
+    unsafe extern "C" {
+        fn malloc_zone_pressure_relief(zone: *mut c_void, goal: size_t) -> size_t;
+    }
+
+    // A null zone asks libmalloc to examine all zones. A zero goal requests as
+    // much relief as the allocator can currently provide.
+    unsafe { malloc_zone_pressure_relief(std::ptr::null_mut(), 0) as usize }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn release_unused_allocator_memory() -> usize {
+    0
+}

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -4,6 +4,7 @@ pub mod download;
 pub mod ipc;
 pub mod logging;
 pub mod mcp_instructions;
+pub mod memory;
 pub mod onnxruntime;
 pub mod openjtalk;
 pub mod paths;


### PR DESCRIPTION


## Why
Longer synthesis results could exceed the daemon server's write-side frame limit and close the connection, which surfaced to clients as "No response from daemon" even though the daemon process stayed alive. On macOS Tohae, unloaded VOICEVOX models also left the daemon with higher resident memory than expected between requests.

## What
Use the daemon's declared response-frame budget on the server side as well as the client side, preserving the smaller request limit while allowing synthesized WAV responses to use the larger response limit already defined by the IPC contract. Keep the no-model-cache policy by making VOICEVOX Core a per-request resource instead of daemon-idle state; this trades some startup work per synthesis for predictable resident memory, which matches the existing design preference for bounded memory over latency. Add a small infrastructure-level allocator relief hook so macOS can return freed native allocations to the OS after model/Core teardown, while non-macOS platforms keep a no-op path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management during voice model unloading operations.

* **Chores**
  * Enhanced daemon IPC communication to support larger message frame sizes.
  * Optimized synthesis process with lazy initialization and automatic memory cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->